### PR TITLE
Bump and cli dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![build status](https://github.com/AndcultureCode/AndcultureCode.Cli.PluginExample/actions/workflows/main.yml/badge.svg)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 A sample project setup showcasing the ability to extend the base functionality of the [`and-cli`](https://github.com/andculturecode/AndcultureCode.Cli) package for project-specific needs.
@@ -73,7 +74,7 @@ Click to see code sample
     // -----------------------------------------------------------------------------------------
 
     // Register all of the base commands from the and-cli with this application
-    CommandRegistry.registerBaseCommands();
+    CommandRegistry.registerAllBase();
 
     program.parse(process.argv);
 
@@ -135,7 +136,7 @@ Click to see code sample
     // -----------------------------------------------------------------------------------------
 
     // Register a single base command from the and-cli with this application
-    CommandRegistry.registerBaseCommand("dotnet");
+    CommandRegistry.registerBase("dotnet");
 
     program.parse(process.argv);
 
@@ -188,11 +189,11 @@ Click to see code sample
     // -----------------------------------------------------------------------------------------
 
     // Register all of the base commands from the and-cli with this application
-    CommandRegistry.registerBaseCommands();
+    CommandRegistry.registerAllBase();
 
     // Register a custom command in the current project (filename must match <cli-name>-<command-name>.js)
     // ie, this command maps up to `plugin-cli-example.js`
-    CommandRegistry.registerCommand(
+    CommandRegistry.register(
         {
             command: "example",
             description: "Some example command",
@@ -260,7 +261,7 @@ Click to see code sample
     // -----------------------------------------------------------------------------------------
 
     // Register all of the base commands from the and-cli with this application
-    CommandRegistry.registerBaseCommands();
+    CommandRegistry.registerAllBase();
 
     // Register an alias for the dotnet command and the dotnet command with specific options
     CommandRegistry
@@ -341,7 +342,7 @@ Click to see code sample
 
     // Register a custom command in the current project (filename must match <cli-name>-<command-name>.js)
     // ie, this command maps up to `plugin-cli-example.js`
-    CommandRegistry.registerCommand(
+    CommandRegistry.register(
         {
             command: "example",
             description: "Some example command",
@@ -412,10 +413,10 @@ To override a base command with one that you've implemented yourself, each `regi
 // ... imports, entrypoint, etc.
 
 // Register a single base command from the and-cli with this application
-CommandRegistry.registerBaseCommand("dotnet");
+CommandRegistry.registerBase("dotnet");
 
 // Override the 'dotnet' command from and-cli with our own custom version
-CommandRegistry.registerCommand(
+CommandRegistry.register(
     {
         command: "dotnet",
         description: "Some custom version of the dotnet command",
@@ -430,13 +431,13 @@ Under the hood, this is just checking to see if a command of the same name has a
 // ... imports, entrypoint, etc.
 
 // Register all of the base commands from the and-cli with this application
-CommandRegistry.registerBaseCommands();
+CommandRegistry.registerAllBase();
 
 // Remove just the base 'dotnet' command
 CommandRegistry.removeCommand("dotnet");
 
 // Add our custom version of the 'dotnet' command now that there's no name conflict
-CommandRegistry.registerCommand(
+CommandRegistry.register(
     {
         command: "dotnet",
         description: "Some custom version of the dotnet command",

--- a/modules/dotnet-version.js
+++ b/modules/dotnet-version.js
@@ -20,7 +20,7 @@ const dotnetVersion = {
         return `Outputs information about the installed dotnet SDKs (via ${this.cmd()})`;
     },
     getOptions() {
-        return new OptionStringBuilder("version", "v");
+        return new OptionStringBuilder("sdk-version");
     },
     run() {
         const { cmd, args } = this.cmd();

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,71 +5,72 @@
     "requires": true,
     "dependencies": {
         "@babel/runtime": {
-            "version": "7.12.5",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-            "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+            "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
         },
         "@octokit/auth-token": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.4.tgz",
-            "integrity": "sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+            "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
             "requires": {
-                "@octokit/types": "^6.0.0"
+                "@octokit/types": "^6.0.3"
             }
         },
         "@octokit/core": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.2.2.tgz",
-            "integrity": "sha512-cZEP6dC8xpepbAqtdS1GgX88omLer8VQegw5BpQ5fbSrkxgY9Y9K7ratu8ezAd9bD0GVOR1GVWiRzYdxiprU1w==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.4.0.tgz",
+            "integrity": "sha512-6/vlKPP8NF17cgYXqucdshWqmMZGXkuvtcrWCgU5NOI0Pl2GjlmZyWgBMrU8zJ3v2MJlM6++CiB45VKYmhiWWg==",
             "requires": {
-                "@octokit/auth-token": "^2.4.0",
-                "@octokit/graphql": "^4.3.1",
-                "@octokit/request": "^5.4.0",
-                "@octokit/types": "^6.0.0",
-                "before-after-hook": "^2.1.0",
+                "@octokit/auth-token": "^2.4.4",
+                "@octokit/graphql": "^4.5.8",
+                "@octokit/request": "^5.4.12",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.0.3",
+                "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/endpoint": {
-            "version": "6.0.10",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.10.tgz",
-            "integrity": "sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==",
+            "version": "6.0.11",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+            "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
             "requires": {
-                "@octokit/types": "^6.0.0",
+                "@octokit/types": "^6.0.3",
                 "is-plain-object": "^5.0.0",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/graphql": {
-            "version": "4.5.8",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.8.tgz",
-            "integrity": "sha512-WnCtNXWOrupfPJgXe+vSmprZJUr0VIu14G58PMlkWGj3cH+KLZEfKMmbUQ6C3Wwx6fdhzVW1CD5RTnBdUHxhhA==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.2.tgz",
+            "integrity": "sha512-WmsIR1OzOr/3IqfG9JIczI8gMJUMzzyx5j0XXQ4YihHtKlQc+u35VpVoOXhlKAlaBntvry1WpAzPl/a+s3n89Q==",
             "requires": {
                 "@octokit/request": "^5.3.0",
-                "@octokit/types": "^6.0.0",
+                "@octokit/types": "^6.0.3",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/openapi-types": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-1.2.2.tgz",
-            "integrity": "sha512-vrKDLd/Rq4IE16oT+jJkDBx0r29NFkdkU8GwqVSP4RajsAvP23CMGtFhVK0pedUhAiMvG1bGnFcTC/xCKaKgmw=="
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.0.tgz",
+            "integrity": "sha512-o00X2FCLiEeXZkm1Ab5nvPUdVOlrpediwWZkpizUJ/xtZQsJ4FiQ2RB/dJEmb0Nk+NIz7zyDePcSCu/Y/0M3Ew=="
         },
         "@octokit/plugin-paginate-rest": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.6.1.tgz",
-            "integrity": "sha512-DprxhI/8Qf/x9Svy89RUh3szyiLwgHL67S5kNmm5B4AjcWrPpMzB25fMCZeIIaXT463Fdn6fc1Hy6kK7/Hd90Q==",
+            "version": "2.13.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+            "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
             "requires": {
-                "@octokit/types": "^6.0.1"
+                "@octokit/types": "^6.11.0"
             }
         },
         "@octokit/plugin-request-log": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz",
-            "integrity": "sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+            "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ=="
         },
         "@octokit/plugin-rest-endpoint-methods": {
             "version": "4.0.0",
@@ -91,26 +92,24 @@
             }
         },
         "@octokit/request": {
-            "version": "5.4.11",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.11.tgz",
-            "integrity": "sha512-vskebNjuz4oTdPIv+9cQjHvjk8vjrMv2fOmSo6zr7IIaFHeVsJlG/C07MXiSS/+g/qU1GHjkPG1XW3faz57EoQ==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.5.0.tgz",
+            "integrity": "sha512-jxbMLQdQ3heFMZUaTLSCqcKs2oAHEYh7SnLLXyxbZmlULExZ/RXai7QUWWFKowcGGPlCZuKTZg0gSKHWrfYEoQ==",
             "requires": {
                 "@octokit/endpoint": "^6.0.1",
                 "@octokit/request-error": "^2.0.0",
-                "@octokit/types": "^6.0.0",
-                "deprecation": "^2.0.0",
+                "@octokit/types": "^6.16.1",
                 "is-plain-object": "^5.0.0",
                 "node-fetch": "^2.6.1",
-                "once": "^1.4.0",
                 "universal-user-agent": "^6.0.0"
             }
         },
         "@octokit/request-error": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.4.tgz",
-            "integrity": "sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+            "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
             "requires": {
-                "@octokit/types": "^6.0.0",
+                "@octokit/types": "^6.0.3",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             }
@@ -127,18 +126,22 @@
             }
         },
         "@octokit/types": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.0.3.tgz",
-            "integrity": "sha512-6y0Emzp+uPpdC5QLzUY1YRklvqiZBMTOz2ByhXdmTFlc3lNv8Mi28dX1U1b4scNtFMUa3tkpjofNFJ5NqMJaZw==",
+            "version": "6.16.2",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.2.tgz",
+            "integrity": "sha512-wWPSynU4oLy3i4KGyk+J1BLwRKyoeW2TwRHgwbDz17WtVFzSK2GOErGliruIx8c+MaYtHSYTx36DSmLNoNbtgA==",
             "requires": {
-                "@octokit/openapi-types": "^1.2.0",
-                "@types/node": ">= 8"
+                "@octokit/openapi-types": "^7.2.3"
             }
         },
+        "@types/lodash": {
+            "version": "4.14.108",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
+            "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA=="
+        },
         "@types/node": {
-            "version": "14.14.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-            "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
+            "version": "15.12.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
+            "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww=="
         },
         "aggregate-error": {
             "version": "3.1.0",
@@ -149,53 +152,70 @@
                 "indent-string": "^4.0.0"
             }
         },
+        "ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
         "and-cli": {
-            "version": "2.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/and-cli/-/and-cli-2.0.0-beta.2.tgz",
-            "integrity": "sha512-dnkvEp9DHO1wboz745OYd9GGn3JbE1o88q+kewtyxR4WjOhCDFlJjjN1EJTKRMpAVIqVDVshqVf2CzrrLw1fyg==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/and-cli/-/and-cli-2.7.1.tgz",
+            "integrity": "sha512-0T745Pvt0h6vOqOWf4bDSmEx7WRkx7WHMVLzw3+q1+OYRKG2fJWdc2TyF1UaJbaoUlZOlXbF55X7OhNqNbSnJQ==",
             "requires": {
                 "@octokit/rest": "18.0.0",
-                "andculturecode-javascript-core": "0.2.0",
+                "andculturecode-javascript-core": "0.4.1",
                 "archiver": "3.1.1",
-                "commander": "5.1.0",
+                "commander": "6.2.1",
                 "find-package-json": "1.2.0",
                 "fkill": "6.2.0",
+                "node-fetch": "2.6.1",
                 "octokit-auth-netrc": "1.0.0",
                 "ps-list": "6.2.0",
                 "readline-promise": "1.0.4",
                 "require-all": "3.0.0",
-                "shelljs": "0.8.3",
+                "shelljs": "0.8.4",
+                "table": "6.0.4",
                 "upath": "1.2.0"
             },
             "dependencies": {
                 "commander": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-                    "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
-                },
-                "shelljs": {
-                    "version": "0.8.3",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-                    "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
-                    "requires": {
-                        "glob": "^7.0.0",
-                        "interpret": "^1.0.0",
-                        "rechoir": "^0.6.2"
-                    }
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+                    "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
                 }
             }
         },
         "andculturecode-javascript-core": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/andculturecode-javascript-core/-/andculturecode-javascript-core-0.2.0.tgz",
-            "integrity": "sha512-TmbOIyu2+3LnLM20duxaptyGJCokItBTBF//374yU/ejUC8D1C5ekz8pAtd2CIZUgsocxpAOTeIxSt8hU1k5iw==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/andculturecode-javascript-core/-/andculturecode-javascript-core-0.4.1.tgz",
+            "integrity": "sha512-Ek4Q8/l793rlKuav6ALV37gy4d82edMV1gYnfZP1DKyTu6LKBnoJJCE2KmRm90sBGQvUHLe/JICHY5MyDDER5Q==",
             "requires": {
+                "@types/lodash": "4.14.108",
                 "axios": "0.19.2",
                 "humanize-plus": "1.8.2",
                 "i18next": "19.4.5",
                 "immutable": "4.0.0-rc.12",
                 "lodash": "4.17.19",
                 "query-string": "6.13.1"
+            }
+        },
+        "ansi-regex": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "requires": {
+                "color-convert": "^2.0.1"
             }
         },
         "archiver": {
@@ -250,6 +270,11 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
             "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
         },
+        "astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+        },
         "async": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
@@ -277,14 +302,14 @@
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "before-after-hook": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
-            "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+            "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
         },
         "bl": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -342,6 +367,19 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
             "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+        },
+        "color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "requires": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "commander": {
             "version": "6.0.0",
@@ -446,6 +484,11 @@
             "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
             "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
+        "emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
         "end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -467,6 +510,16 @@
                 "signal-exit": "^3.0.0",
                 "strip-eof": "^1.0.0"
             }
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "find-package-json": {
             "version": "1.2.0",
@@ -569,9 +622,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
         "has": {
             "version": "1.0.3",
@@ -649,6 +702,11 @@
                 "has": "^1.0.3"
             }
         },
+        "is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
         "is-plain-object": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -673,6 +731,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -986,6 +1049,11 @@
                 "once": "^1.3.1"
             }
         },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
         "query-string": {
             "version": "6.13.1",
             "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
@@ -1081,6 +1149,16 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
         },
+        "slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            }
+        },
         "split-on-first": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
@@ -1099,12 +1177,30 @@
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
             "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
+        "string-width": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+            "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+            "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
+            }
+        },
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
                 "safe-buffer": "~5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+            "requires": {
+                "ansi-regex": "^5.0.0"
             }
         },
         "strip-eof": {
@@ -1117,10 +1213,28 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
         },
+        "table": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.0.4.tgz",
+            "integrity": "sha512-sBT4xRLdALd+NFBvwOz8bw4b15htyythha+q+DVZqy2RS08PPC8O2sZFgJYEY7bJvbCFKccs+WIZ/cd+xxTWCw==",
+            "requires": {
+                "ajv": "^6.12.4",
+                "lodash": "^4.17.20",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.0"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.21",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+                    "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+                }
+            }
+        },
         "tar-stream": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-            "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
             "requires": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -1270,6 +1384,14 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+        },
+        "uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "plugin-cli": "plugin-cli.js"
     },
     "dependencies": {
-        "and-cli": "2.0.0-beta.2",
+        "and-cli": "2.7.1",
         "commander": "6.0.0",
         "shelljs": "0.8.4"
     },

--- a/plugin-cli-dotnet.js
+++ b/plugin-cli-dotnet.js
@@ -20,8 +20,9 @@ CommandRunner.run(async () => {
         .option(dotnetVersion.getOptions().toString(), dotnetVersion.description())
         .parse(process.argv);
 
-    // If no options are passed in, just runs dotnet version module
-    if (Js.hasNoArguments()) {
+    const { sdkVersion } = program.opts();
+
+    if (Js.hasNoArguments() || sdkVersion) {
         dotnetVersion.run();
     }
 

--- a/plugin-cli.js
+++ b/plugin-cli.js
@@ -5,7 +5,7 @@
 // -----------------------------------------------------------------------------------------
 
 
-const { program, Commands, CommandRegistry } = require("and-cli");
+const { program, CommandDefinitions, CommandRegistry } = require("and-cli");
 
 // #endregion Imports
 
@@ -25,7 +25,7 @@ CommandRegistry.registerAllBase();
 CommandRegistry.registerBase("dotnet", true);
 
 // Or, strongly typed with the command definitions
-CommandRegistry.registerBase(Commands.dotnet.command, true);
+CommandRegistry.registerBase(CommandDefinitions.dotnet.command, true);
 
 // Override the 'dotnet' command from and-cli with our own custom version
 CommandRegistry.register(

--- a/plugin-cli.js
+++ b/plugin-cli.js
@@ -19,16 +19,16 @@ program.description(
 );
 
 // Register all of the base commands from the and-cli with this application
-CommandRegistry.registerBaseCommands();
+CommandRegistry.registerAllBase();
 
 // Register a single base command from the and-cli with this application
-CommandRegistry.registerBaseCommand("dotnet", true);
+CommandRegistry.registerBase("dotnet", true);
 
 // Or, strongly typed with the command definitions
-CommandRegistry.registerBaseCommand(Commands.dotnet.command, true);
+CommandRegistry.registerBase(Commands.dotnet.command, true);
 
 // Override the 'dotnet' command from and-cli with our own custom version
-CommandRegistry.registerCommand(
+CommandRegistry.register(
     {
         command: "dotnet",
         description: "Some custom version of the dotnet command",
@@ -37,7 +37,7 @@ CommandRegistry.registerCommand(
 );
 
 // The command registry also provides a function for registering multiple commands at once
-CommandRegistry.registerCommands([
+CommandRegistry.registerAll([
     {
         command: "example",
         description: "Some example command",


### PR DESCRIPTION
Resolves #10 Bump and-cli from 2.0.0-beta.2 to 2.7.1

Bumps `and-cli` to latest version and updates references to renamed functions. Additionally, fixed an issue with the `dotnet --version` example command flag that conflicts with the base `--version` flag from commander.

-   [x] Related GitHub issue(s) linked in PR description
-   [x] Destination branch merged, built and tested with your changes
-   [x] Code formatted and follows best practices and patterns
-   [x] Code builds cleanly (no _additional_ warnings or errors)
-   [x] Manually tested
-   [x] Automated tests are passing
-   [-] No _decreases_ in automated test coverage
-   [x] Documentation updated (readme, docs, comments, etc.)
-   [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
